### PR TITLE
Add CPU-only PyTorch environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # pt_math
+
+This repository contains resources for experiments with PyTorch-based math models.
+
+## Setting up the `ptmath` CPU environment
+
+Use the provided setup script to create a Python virtual environment with CPU-only PyTorch:
+
+```bash
+bash setup_ptmath_cpu.sh
+```
+
+This creates a virtual environment named `ptmath` and installs PyTorch, torchvision, and torchaudio compiled for CPU. Activate the environment with:
+
+```bash
+source ptmath/bin/activate
+```
+

--- a/setup_ptmath_cpu.sh
+++ b/setup_ptmath_cpu.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Script to set up a CPU-only PyTorch environment named 'ptmath'
+# Usage: bash setup_ptmath_cpu.sh
+
+set -e
+
+python -m venv ptmath
+source ptmath/bin/activate
+
+# Upgrade pip and install CPU-only PyTorch packages
+python -m pip install --upgrade pip
+python -m pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
+
+echo "Environment 'ptmath' created with CPU-only PyTorch."


### PR DESCRIPTION
## Summary
- add instructions for CPU-only PyTorch setup in README
- provide `setup_ptmath_cpu.sh` script to create a `ptmath` virtual environment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68447f047a508326af776d9ef638827e