### PR TITLE
Measure torch.exp accuracy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+ptmath/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -10,9 +10,19 @@ Use the provided setup script to create a Python virtual environment with CPU-on
 bash setup_ptmath_cpu.sh
 ```
 
-This creates a virtual environment named `ptmath` and installs PyTorch, torchvision, and torchaudio compiled for CPU. Activate the environment with:
+Activate the environment with:
 
 ```bash
 source ptmath/bin/activate
 ```
+
+## Measuring `torch.exp` accuracy
+
+Run the `measure_exp_accuracy.py` script inside the environment to compute the ULP error of `torch.exp` in float32 against a double precision reference:
+
+```bash
+python measure_exp_accuracy.py
+```
+
+The script prints summary statistics and saves the ULP errors to `exp_accuracy.csv`.
 

--- a/measure_exp_accuracy.py
+++ b/measure_exp_accuracy.py
@@ -1,0 +1,36 @@
+import numpy as np
+try:
+    import torch
+except ImportError:
+    raise SystemExit('PyTorch is not installed')
+
+NUM_SAMPLES = 100000
+# range of inputs for exp
+inputs = np.linspace(-20, 20, NUM_SAMPLES, dtype=np.float32)
+
+# torch computation (float32)
+xt = torch.from_numpy(inputs)
+with torch.no_grad():
+    yt = torch.exp(xt).numpy()
+
+# reference using double precision
+ref = np.exp(inputs.astype(np.float64)).astype(np.float32)
+
+def ulp_diff(a, b):
+    ai = np.frombuffer(np.float32(a).tobytes(), dtype=np.uint32)
+    bi = np.frombuffer(np.float32(b).tobytes(), dtype=np.uint32)
+    return np.abs(ai.astype(np.int64) - bi.astype(np.int64))
+
+ulps = ulp_diff(yt, ref)
+
+max_ulp = ulps.max()
+mean_ulp = ulps.mean()
+print(f"max ULP error: {max_ulp}")
+print(f"mean ULP error: {mean_ulp:.4f}")
+
+np.savetxt('exp_accuracy.csv',
+           np.column_stack((inputs, ulps)),
+           delimiter=',',
+           header='input,ulp_error',
+           comments='')
+print('results saved to exp_accuracy.csv')


### PR DESCRIPTION
## Summary
- add instructions on using the ptmath CPU environment
- script to measure torch.exp float32 accuracy vs. double precision
- record ULP error results to a CSV file instead of a PNG plot
- ignore the virtual environment directory

## Testing
- `python -m py_compile measure_exp_accuracy.py`
- `python measure_exp_accuracy.py`

------
https://chatgpt.com/codex/tasks/task_e_6844812186448326b413103d60900ce2